### PR TITLE
example

### DIFF
--- a/example/agent.hcl
+++ b/example/agent.hcl
@@ -3,5 +3,11 @@
 
 log_level = "TRACE"
 
+client {
+  options = {
+    "driver.allowlist" = "dotnet"
+  }
+}
+
 plugin "dotnet" {
 }

--- a/example/example.nomad
+++ b/example/example.nomad
@@ -1,17 +1,21 @@
-group "example" {
-  task "dotnet_test" {
-    driver = "dotnet"
-    config {
-      dll_path = "${NOMAD_TASK_DIR}/TestNomadTask.dll"
-      threading {
-        min_threads = 10
-        max_threads = 100
+job "example" {
+  group "example" {
+    task "dotnet_test" {
+      driver = "dotnet"
+
+      config {
+        dll_path = "${NOMAD_TASK_DIR}/TestNomadTask.dll"
+        threading {
+          min_threads = 10
+          max_threads = 100
+        }
+        args = ["9090"]
       }
-      args = ["9090"]
-    }
-    artifact {
-      source = "http://localhost/test_nomad_task.zip"
-      destination = "local"
+
+      artifact {
+     source = "http://localhost/test_nomad_task.zip"
+     destination = "local"
+      }
     }
   }
 }


### PR DESCRIPTION
2 tiny fix on example:
   - add "driver.allowlist" = "dotnet" to .hcl file to prevent from other drivers warning logs during agent startup
   - fix .nomad file structure