### PR TITLE
pass plugin binary name to declare plugin config

### DIFF
--- a/example/agent.hcl
+++ b/example/agent.hcl
@@ -9,5 +9,8 @@ client {
   }
 }
 
-plugin "dotnet" {
+plugin "nomad-dotnet-driver" {
+    config {
+        sdk_path = "/usr/local/bin/dotnet"
+    }
 }


### PR DESCRIPTION
This PR includes a minor fix and some code cleanup:

Fix: Pass the PLUGIN_BINARY value as the plugin name to specify the plugin configuration.
Clean: Assign the Config structure to a pointer (*config) in the driver.
Clean: Revert `dll_path` to not-required taskConfig and `sdk_path` as required Config