### PR TITLE
Use Relative Paths and Extract App Name from DLL's name

### DIFF
--- a/dotnet/driver.go
+++ b/dotnet/driver.go
@@ -97,7 +97,6 @@ var (
 		// but that's not expressible in hclspec.  Marking both as optional
 		// and setting checking explicitly later
 		"dll_path":        hclspec.NewAttr("dll_path", "string", true),
-		"app_name":        hclspec.NewAttr("app_name", "string", true),
 		"runtime_version": hclspec.NewAttr("runtime_version", "string", false),
 		"gc": hclspec.NewBlock("gc", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"enable":               hclspec.NewAttr("enable", "bool", false),
@@ -211,9 +210,6 @@ type TaskConfig struct {
 
 	// DotnetPath indicates where a dll file is found.
 	DotnetPath string `codec:"dll_path"`
-
-	// AppName indicates the .Net application name.
-	AppName string `codec:"app_name"`
 
 	// SdkVersion indicates which version of dotnet the task must be run
 	RuntimeVersion *string `codec:"runtime_version"`
@@ -499,7 +495,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	addGlobalizationConfig(taskConfig.Globalization, fileConfig)
 	addThreadingConfig(taskConfig.Threading, fileConfig)
 
-	dotnetConfigPath := path.Join(cfg.TaskDir().LocalDir, fmt.Sprintf("%s.runtimeconfig.json", taskConfig.AppName))
+	appName, _ := getDotnetAppName(taskConfig.DotnetPath)
+	dotnetConfigPath := path.Join(cfg.TaskDir().LocalDir, fmt.Sprintf("%s.runtimeconfig.json", appName))
 
 	if content, err := os.ReadFile(dotnetConfigPath); !os.IsNotExist(err) {
 		var parsedConfig = new(ConfigFile)
@@ -514,10 +511,10 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	data, _ := json.Marshal(fileConfig)
 	fo, err := os.Create(dotnetConfigPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create %s.runtimeconfig.json: %v", taskConfig.AppName, err)
+		return nil, nil, fmt.Errorf("failed to create %s.runtimeconfig.json: %v", appName, err)
 	}
 	if _, err := fo.Write(data); err != nil {
-		return nil, nil, fmt.Errorf("failed to write %s.runtimeconfig.json: %v", taskConfig.AppName, err)
+		return nil, nil, fmt.Errorf("failed to write %s.runtimeconfig.json: %v", appName, err)
 	}
 	defer func(fo *os.File) {
 		err := fo.Close()

--- a/dotnet/driver.go
+++ b/dotnet/driver.go
@@ -492,7 +492,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, err
 	}
 
-	args := dotnetCmdArgs(taskConfig)
+	args := dotnetCmdArgs(*cfg, taskConfig)
 
 	var fileConfig = new(ConfigFile)
 	addGcConfig(taskConfig.GC, fileConfig)
@@ -625,7 +625,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 	return handle, nil, nil
 }
 
-func dotnetCmdArgs(taskConfig TaskConfig) []string {
+func dotnetCmdArgs(driverConfig drivers.TaskConfig, taskConfig TaskConfig) []string {
 	var args []string
 
 	//Add runtime version
@@ -635,7 +635,7 @@ func dotnetCmdArgs(taskConfig TaskConfig) []string {
 
 	// Add the dll
 	if taskConfig.DotnetPath != "" {
-		args = append(args, taskConfig.DotnetPath)
+		args = append(args, fmt.Sprintf("%s/%s", driverConfig.TaskDir().LocalDir, taskConfig.DotnetPath))
 	}
 
 	// Add any args

--- a/dotnet/utils.go
+++ b/dotnet/utils.go
@@ -17,6 +17,15 @@ var (
 	runtimeVersionRe = regexp.MustCompile(`\b\d+\.\d+\.\d+\b`)
 )
 
+func getDotnetAppName(dotnetPath string) (string, error) {
+	re := regexp.MustCompile(`([^/]+)\.dll$`)
+	match := re.FindStringSubmatch(dotnetPath)
+	if len(match) > 1 {
+		return match[1], nil
+	} else {
+		return "", fmt.Errorf("could not extract app name from %s", dotnetPath)
+	}
+}
 func getDotnetPath() (string, error) {
 	switch runtime.GOOS {
 	case "windows":

--- a/example/example.nomad
+++ b/example/example.nomad
@@ -4,8 +4,7 @@ job "example" {
       driver = "dotnet"
 
       config {
-        dll_path = "${NOMAD_TASK_DIR}/TestNomadTask.dll"
-        app_name = "TestNomadTask"
+        dll_path = "TestNomadTask.dll"
         runtime_version = "8.0.8"
         threading {
           min_threads = 10
@@ -32,8 +31,7 @@ job "example" {
           driver = "dotnet"
 
           config {
-            dll_path = "${NOMAD_TASK_DIR}/TestNomadTask.dll"
-            app_name = "TestNomadTask"
+            dll_path = "TestNomadTask.dll"
             runtime_version = "7.0.20"
             threading {
               min_threads = 10


### PR DESCRIPTION
These changes align the config struct with convention over configuration principles, making it easier to set up with fewer fields.
**1. Relative dll_path over abstract path in configs**
**2. Remove `appName` from configs**